### PR TITLE
Remove deprecated Renovate preset alias

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Onboarding preset for use with Ghost's repos",
-  "extends": ["github>tryghost/renovate-config"]
-}


### PR DESCRIPTION
## Summary
- remove `renovate-config.json` from `TryGhost/.github`
- all known repos using `local>TryGhost/.github:renovate-config` have been migrated to `github>TryGhost/renovate-config`
- keep a single canonical Renovate preset source to reduce indirection and confusion